### PR TITLE
fixes #2  where running gitsbt on the command-line returns error

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,7 +35,7 @@ if (args.length > 0) {
         }
     });
 } else {
-    console.log('usage: git-subtree <command>\n');
+    console.log('usage: gitsbt <command>\n');
     console.log('Commands:');
     console.log('init\tInitialize project subtrees');
     console.log('add\tCreate remote, fetch and add subtree folder');

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,22 @@
+{
+  "name": "git-subtree",
+  "version": "0.2.0",
+  "lockfileVersion": 1,
+  "dependencies": {
+    "async": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+      "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
+    },
+    "colors": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
+      "integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM="
+    },
+    "lodash": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+      "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
-  "bin": "bin/gitsbt",
+  "bin": {
+    "gitsbt": "bin/gitsbt"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/plitex/git-subtree.git"


### PR DESCRIPTION
fixes #2  where running gitsbt on the command-line returns error of command not found after npm install per README.md.  Updated to fix both 'bin' section of package.json and helper output when used without including a command.   Note:  Was using npm 5 to do this work...which produces a package-log.json file.   I'm adding this file per npm guidance.  Shouldn't cause issue with older versions of npm.